### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,8 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" href="//cdn.rawgit.com/nicgirault/circosJS/master/dist/colorBrewer.css"></link>
+    <script src="//raw.githack.com/nicgirault/circosJS/master/dist/circosJS.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-    // Extend website resources and html
-    website: {
-        html: {
-            "head:end": "<script src='https://raw.githack.com/nicgirault/circosJS/master/dist/circosJS.js'></script>\n<script src='https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js'></script>\n<link rel='stylesheet' href='https://cdn.rawgit.com/nicgirault/circosJS/master/dist/colorBrewer.css'></link>"
-        }
-    }
-};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "gitbook-plugin-circosjs",
     "description": "Gitbook plugin to include js in templates",
-    "main": "index.js",
     "version": "0.0.3",
     "engines": {
         "gitbook": "*"


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and directly includes the scripts and stylesheets using GitBook 3 templating.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

If you release a new version, please upgrade the gitbook engine in `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
